### PR TITLE
Curl should fail if it fails :)

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -34,7 +34,7 @@ hooks:
     build: |
         set -x -e
 
-        curl -s https://get.symfony.com/cloud/configurator | bash
+        curl -s --fail https://get.symfony.com/cloud/configurator | bash
         symfony-build
     deploy: |
         set -x -e


### PR DESCRIPTION
I experienced a situation where curl failed, and of course without --fail it doesn't tell you so. Especially in a pipe situation. If we could count on bash, this should have `set -eu -o pipefail`